### PR TITLE
Make platformSupported actually callable before glfwInit

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -358,7 +358,6 @@ pub fn getPlatform() PlatformType {
 ///
 /// thread_safety: This function may be called from any thread.
 pub fn platformSupported(platform: PlatformType) bool {
-    internal_debug.assertInitialized();
     return c.glfwPlatformSupported(@intFromEnum(platform)) == c.GLFW_TRUE;
 }
 


### PR DESCRIPTION
`glfw.platformSupported` had an unnecessary assert that prevented it from being called in debug builds before glfwInit.
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.